### PR TITLE
feat: Add SPM Release GitHub Action

### DIFF
--- a/.github/scripts/DownloadLatestFrameworkAndDocs.sh
+++ b/.github/scripts/DownloadLatestFrameworkAndDocs.sh
@@ -1,0 +1,24 @@
+VERSION_NUM=$1
+
+BASE_URL="https://agora.dequecloud.com/artifactory/Attest-iOS/axeDevToolsXCUI"
+FRAMEWORK_FILENAME="axeDevToolsXCUI.xcframework-${VERSION_NUM}"
+DOCS_FILENAME="axeDevToolsXCUI.doccarchive-${VERSION_NUM}"
+
+FRAMEWORK_URL="${BASE_URL}/frameworks/${FRAMEWORK_FILENAME}.zip"
+DOCS_URL="${BASE_URL}/docs/${DOCS_FILENAME}.zip"
+
+OUTPUT_DIR="/tmp/unzipped"
+LOCAL_ZIPPED_FRAMEWORK_URL="${OUTPUT_DIR}/${FRAMEWORK_FILENAME}.zip"
+LOCAL_ZIPPED_DOCS_URL="${OUTPUT_DIR}/${DOCS_FILENAME}.zip"
+
+mkdir -p $OUTPUT_DIR
+
+# Download framework & docs
+curl -H "X-JFrog-Art-Api:${DQ_AGORA_KEY}" -o $LOCAL_ZIPPED_FRAMEWORK_URL $FRAMEWORK_URL
+curl -H "X-JFrog-Art-Api:${DQ_AGORA_KEY}" -o $LOCAL_ZIPPED_DOCS_URL $DOCS_URL
+
+# Unzip framework & docs
+unzip -o $LOCAL_ZIPPED_FRAMEWORK_URL -d .
+unzip -o $LOCAL_ZIPPED_DOCS_URL -d .
+
+ls -al .

--- a/.github/workflows/spm-release.yml
+++ b/.github/workflows/spm-release.yml
@@ -1,0 +1,51 @@
+name: Release to SPM
+on:
+    workflow_dispatch:
+        inputs:
+            releaseVersion:
+                description: 'The version/tag of the release'
+                required: true
+
+jobs:
+    update_spm:
+        runs-on: ubuntu-latest
+        steps:
+
+          - name: Checkout main branch
+            uses: actions/checkout@v4
+            with:
+                ref: main
+
+          - name: Remove existing framework and docs
+            run: |
+                rm -rf axeDevToolsXCUI.*
+
+          - name: Download latest XCUI framework & DocC archive
+            env:
+                DQ_AGORA_KEY: ${{ secrets.DQ_AGORA_KEY }}
+            run: |
+                sh .github/scripts/DownloadLatestFrameworkAndDocs.sh ${{ github.event.inputs.releaseVersion }}
+
+          - name: Commit changes
+            run: |
+                git config user.name "deque-mobileteam"
+                git config user.email "mobileteam@deque.com"
+                git add axeDevToolsXCUI.*
+                git commit -m "chore: release ${{ github.event.inputs.releaseVersion }}"
+                git push
+
+          - name: Create and push tag
+            run: |
+                git tag -a ${{ github.event.inputs.releaseVersion }} -m "Release ${{ github.event.inputs.releaseVersion }}"
+                git push origin tag ${{ github.event.inputs.releaseVersion }}
+
+          - name: Create GitHub release
+            uses: softprops/action-gh-release@v2
+            with:
+                tag_name: ${{ github.event.inputs.releaseVersion }}
+                release_name: ${{ github.event.inputs.releaseVersion }}
+                generate_release_notes: true
+                draft: false
+                prerelease: false
+
+    


### PR DESCRIPTION
Closes [#1649](https://github.com/dequelabs/AttestIOS/issues/1649)

This commit adds the first GitHub Action to this repository and automates the process of creating an SPM Release.

This Action is manually kicked off and requires that a version/tag is provided in the semver format (2.x.x).

You can see a video of this process here:

https://github.com/dequelabs/axe-devtools-ios/assets/171582904/70a0c118-53fa-4d13-9a82-9c1f1b5c710e

