### PR TITLE
chore: Notify Dependents of a Release

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -1,0 +1,14 @@
+name: Notify Dependents
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    send-notification:
+        runs-on: ubuntu-latest
+        steps:
+
+          - name: Notify Analyzer
+            run: |
+                curl -X POST 'https://api.github.com/repos/dequelabs/axe-devtools-mobile-analyzer/actions/workflows/test_a_workflow.yml/dispatches' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.CI_WORKFLOW_PAT }}' -d '{"ref": "testing-a-workflow"}'

--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -11,4 +11,4 @@ jobs:
 
           - name: Notify Analyzer
             run: |
-                curl -X POST 'https://api.github.com/repos/dequelabs/axe-devtools-mobile-analyzer/actions/workflows/test_a_workflow.yml/dispatches' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.CI_WORKFLOW_PAT }}' -d '{"ref": "testing-a-workflow"}'
+                curl -X POST 'https://api.github.com/repos/dequelabs/axe-devtools-mobile-analyzer/actions/workflows/publish_latest.yml/dispatches' -H 'Content-Type: application/json' -H 'Authorization: Bearer ${{ secrets.CI_WORKFLOW_PAT }}' -d '{"ref": "main"}'


### PR DESCRIPTION
Helps close #[30](https://github.com/dequelabs/axe-devtools-mobile-analyzer/issues/30)
Associated with #[34](https://github.com/dequelabs/axe-devtools-mobile-analyzer/pull/34)

This workflow will act as a webhook that can notify other repos of a release (like the analyzer) and can potentially trigger any necessary workflows on those repos.