### PR TITLE
chore: Update Github Actions to Use Commit SHA.

### DIFF
--- a/.github/workflows/spm-release.yml
+++ b/.github/workflows/spm-release.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
 
           - name: Checkout main branch
-            uses: actions/checkout@v4
+            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
             with:
                 ref: main
 
@@ -78,7 +78,7 @@ jobs:
                 git push origin tag ${{ github.event.inputs.releaseVersion }}
 
           - name: Create GitHub release
-            uses: softprops/action-gh-release@v2
+            uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
             with:
                 tag_name: ${{ github.event.inputs.releaseVersion }}
                 release_name: ${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
related to [#2046](https://app.zenhub.com/workspaces/mobile---ios-618c5382fb76f00010561506/issues/gh/dequelabs/attestios/2046)

## Summary
Updates all github actions to use commit SHA instead of a version tag for better security practices.

**Does this change effect a customer's experience or result?**
No.

**What was the behavior?**
3rd party actions were referenced by their version tag.

**What is the behavior now?**
3rd party actions will be referenced by a commit SHA.