### PR TITLE
fix(ci): prevent template injection in tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -17,11 +17,13 @@ jobs:
                 ref: main
 
           - name: Create and push tag
+            env:
+                RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
             run: |
                 git config --global user.email "mobileteam@deque.com"
                 git config --global user.name "deque-mobileteam"
-                git tag -a ${{ github.event.inputs.releaseVersion }} -m "Release ${{ github.event.inputs.releaseVersion }}"
-                git push origin tag ${{ github.event.inputs.releaseVersion }}
+                git tag -a "$RELEASE_VERSION" -m "Release $RELEASE_VERSION"
+                git push origin tag "$RELEASE_VERSION"
 
           - name: Create GitHub release
             uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2


### PR DESCRIPTION
## Summary
Relates to iOS Repo 2736: template injection in `.github/workflows/tag-release.yml`.

## Test plan
- [ ] CI on this PR passes.
- [ ] After merge into `develop` → `qa` → `main`, run the **Tag New Release** workflow with a normal semver (e.g. `4.1.1`) and confirm the tag + GitHub release are created as before.
- [ ] (Optional) Dry-run with an unusual input like `1.0.0"; echo pwned; #` and confirm it fails safely at `git tag` rather than executing the injected command.